### PR TITLE
Allow commitment overlaps and fix timer reset issue

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.2lkappqa11o"
+    "revision": "0.mkvd9e3idc"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -3326,12 +3326,12 @@ export const checkCommitmentConflicts = (
       startDate: string;
       endDate: string;
     };
-    type?: string; // Added type to check for all-day events
+    type?: string;
   },
   existingCommitments: FixedCommitment[],
-  excludeCommitmentId?: string // For editing, exclude the commitment being edited
-): { 
-  hasConflict: boolean; 
+  excludeCommitmentId?: string
+): {
+  hasConflict: boolean;
   conflictingCommitment?: FixedCommitment;
   conflictType?: 'strict' | 'override';
   conflictingDates?: string[];

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -3336,12 +3336,9 @@ export const checkCommitmentConflicts = (
   conflictType?: 'strict' | 'override';
   conflictingDates?: string[];
 } => {
-  // Convert time strings to minutes for easier comparison
-  const timeToMinutes = (timeStr?: string): number => {
-    if (!timeStr) return 0; // For all-day events
-    const [hours, minutes] = timeStr.split(':').map(Number);
-    return (hours || 0) * 60 + (minutes || 0);
-  };
+  // Overlap policy: commitments may overlap with other commitments (recurring or one-time)
+  // Therefore we do not flag time conflicts between commitments.
+  return { hasConflict: false };
 
   // For all-day events, use full day time range (00:00 to 23:59)
   const newStartMinutes = newCommitment.isAllDay ? 0 : timeToMinutes(newCommitment.startTime);


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two key issues:
1. **Commitment overlap behavior**: Users expected all commitments to be able to overlap, but the system was preventing recurring commitments from appearing when overlapped by one-time commitments
2. **Timer reset bug**: Users reported that timers weren't resetting properly when marking sessions as completed, requiring app reloads to see the correct state

## Code changes

- **Removed commitment overlap restrictions**: Eliminated complex logic that prevented recurring commitments from showing when overlapped by one-time commitments, and removed one-time commitment override behavior
- **Simplified commitment management**: Removed `applyOneTimeOverridesToRecurring()` and `computeRecurringDeletedFromOneTimes()` functions and their associated logic in create, update, and delete operations
- **Updated calendar drag behavior**: Modified commitment dragging to only move overlapping task sessions, allowing commitments to freely overlap with each other
- **Simplified conflict checking**: Updated `checkCommitmentConflicts()` to always return no conflict, allowing all commitment overlaps
- **Cleaned up cascade logic**: Removed commitment-to-commitment cascade relocations while preserving task session movement when commitments are dragged

The changes maintain existing functionality for task session management while removing the restrictive overlap behavior that was causing user confusion.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f070df200f21427ab9b3afe87b00c020/quantum-hub)

👀 [Preview Link](https://f070df200f21427ab9b3afe87b00c020-quantum-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f070df200f21427ab9b3afe87b00c020</projectId>-->
<!--<branchName>quantum-hub</branchName>-->