### PR TITLE
Fix calendar event clicks to show modal instead of redirect

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.31kfr09h6g"
+    "revision": "0.ttjb0pm6vp8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -180,6 +180,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
     overlappingSessionIds: Array<{ taskId: string; sessionNumber?: number }>;
   }>(null);
 
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
 
   // Persist calendar view to localStorage
   useEffect(() => {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -572,38 +572,18 @@ const CalendarView: React.FC<CalendarViewProps> = ({
   const handleSelectEvent = (event: CalendarEvent) => {
     if (event.resource.type === 'study') {
       const session = event.resource.data as StudySession;
-      // Prevent clicking on done sessions
-      if (session.done) return;
-      const today = getLocalDateString();
-      // Always use planDate from event.resource, fallback to event.start if missing
-      let planDate = event.resource.planDate;
-      if (!planDate && event.start) {
-        planDate = event.start.toISOString().split('T')[0];
-      }
-      if ((planDate === today)) {
-        if (onSelectTask) {
-          onSelectTask(tasks.find(t => t.id === session.taskId)!, {
-            allocatedHours: moment(event.end).diff(moment(event.start), 'hours', true),
-            planDate: planDate,
-            sessionNumber: session.sessionNumber
-          });
-        }
-      }
-      // Otherwise, do nothing (not clickable)
+      if (session.done || session.status === 'completed' || session.status === 'skipped') return;
+      setSelectedEvent(event);
     } else if (event.resource.type === 'commitment') {
       const commitment = event.resource.data as FixedCommitment;
       const today = getLocalDateString();
       const commitmentDate = moment(event.start).format('YYYY-MM-DD');
-
-      // Check if this is a manual rescheduled session
       if (commitment.title.includes('(Manual Resched)')) {
         setSelectedManualSession(commitment);
       } else if (onSelectCommitment && commitmentDate === today) {
-        // Handle clicks on commitments for current day: open timer
         const duration = moment(event.end).diff(moment(event.start), 'hours', true);
         onSelectCommitment(commitment, duration);
       }
-      // Otherwise, do nothing (not clickable for non-current days)
     }
   };
 

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -181,6 +181,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
   }>(null);
 
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+  const [selectedCommitmentEvent, setSelectedCommitmentEvent] = useState<CalendarEvent | null>(null);
 
   // Persist calendar view to localStorage
   useEffect(() => {
@@ -576,13 +577,10 @@ const CalendarView: React.FC<CalendarViewProps> = ({
       setSelectedEvent(event);
     } else if (event.resource.type === 'commitment') {
       const commitment = event.resource.data as FixedCommitment;
-      const today = getLocalDateString();
-      const commitmentDate = moment(event.start).format('YYYY-MM-DD');
       if (commitment.title.includes('(Manual Resched)')) {
         setSelectedManualSession(commitment);
-      } else if (onSelectCommitment && commitmentDate === today) {
-        const duration = moment(event.end).diff(moment(event.start), 'hours', true);
-        onSelectCommitment(commitment, duration);
+      } else {
+        setSelectedCommitmentEvent(event);
       }
     }
   };
@@ -621,6 +619,25 @@ const CalendarView: React.FC<CalendarViewProps> = ({
     });
     onUpdateStudyPlans(updatedPlans);
     setSelectedEvent(null);
+  };
+
+  const handleStartSelectedCommitment = () => {
+    if (!selectedCommitmentEvent || selectedCommitmentEvent.resource.type !== 'commitment' || !onStartManualSession) { setSelectedCommitmentEvent(null); return; }
+    const commitment = selectedCommitmentEvent.resource.data as FixedCommitment;
+    const durationSeconds = Math.max(0, moment(selectedCommitmentEvent.end).diff(moment(selectedCommitmentEvent.start), 'seconds'));
+    onStartManualSession(commitment, durationSeconds);
+    setSelectedCommitmentEvent(null);
+  };
+
+  const handleSkipSelectedCommitment = () => {
+    if (!selectedCommitmentEvent || selectedCommitmentEvent.resource.type !== 'commitment' || !onUpdateCommitment) { setSelectedCommitmentEvent(null); return; }
+    const commitment = selectedCommitmentEvent.resource.data as FixedCommitment;
+    const dateString = moment(selectedCommitmentEvent.start).format('YYYY-MM-DD');
+    const existing = commitment.deletedOccurrences || [];
+    if (!existing.includes(dateString)) {
+      onUpdateCommitment(commitment.id, { deletedOccurrences: [...existing, dateString] });
+    }
+    setSelectedCommitmentEvent(null);
   };
 
   // Utility function to find available time slots with precise placement
@@ -2401,7 +2418,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
         </div>
       )}
 
-      {/* Start/Skip Session Modal */}
+      {/* Start/Skip Study Session Modal */}
       {selectedEvent && selectedEvent.resource.type === 'study' && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={() => setSelectedEvent(null)}>
           <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full mx-4" onClick={e => e.stopPropagation()}>
@@ -2424,6 +2441,41 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                   Skip this session for {moment(selectedEvent.start).format('MMM D')}
                 </button>
                 <button className="w-full px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600" onClick={() => setSelectedEvent(null)}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Start/Skip Commitment Modal */}
+      {selectedCommitmentEvent && selectedCommitmentEvent.resource.type === 'commitment' && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={() => setSelectedCommitmentEvent(null)}>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full mx-4" onClick={e => e.stopPropagation()}>
+            <div className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-bold text-gray-800 dark:text-white">Commitment</h2>
+                <button onClick={() => setSelectedCommitmentEvent(null)} className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+                  <X size={20} />
+                </button>
+              </div>
+              <div className="text-sm text-gray-700 dark:text-gray-300 space-y-1 mb-4">
+                <div className="font-medium">{selectedCommitmentEvent.title}</div>
+                <div>{moment(selectedCommitmentEvent.start).format('ddd, MMM D')} • {moment(selectedCommitmentEvent.start).format('HH:mm')} - {moment(selectedCommitmentEvent.end).format('HH:mm')}</div>
+              </div>
+              <div className="space-y-2">
+                {onStartManualSession && (
+                  <button className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700" onClick={handleStartSelectedCommitment}>
+                    Start session
+                  </button>
+                )}
+                {onUpdateCommitment && (
+                  <button className="w-full px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700" onClick={handleSkipSelectedCommitment}>
+                    Skip this occurrence for {moment(selectedCommitmentEvent.start).format('MMM D')}
+                  </button>
+                )}
+                <button className="w-full px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600" onClick={() => setSelectedCommitmentEvent(null)}>
                   Cancel
                 </button>
               </div>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1157,7 +1157,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
         plannedTasks: [newSession],
         totalStudyHours: sessionDuration,
         isOverloaded: false,
-        availableHours: getDaySpecificDailyHours(newPlanDate, settings)
+        availableHours: getDaySpecificDailyHours(targetDate, settings)
       });
 
       // Also remove from original plan if it exists

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -2401,6 +2401,37 @@ const CalendarView: React.FC<CalendarViewProps> = ({
         </div>
       )}
 
+      {/* Start/Skip Session Modal */}
+      {selectedEvent && selectedEvent.resource.type === 'study' && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={() => setSelectedEvent(null)}>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full mx-4" onClick={e => e.stopPropagation()}>
+            <div className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-bold text-gray-800 dark:text-white">Study Session</h2>
+                <button onClick={() => setSelectedEvent(null)} className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+                  <X size={20} />
+                </button>
+              </div>
+              <div className="text-sm text-gray-700 dark:text-gray-300 space-y-1 mb-4">
+                <div className="font-medium">{selectedEvent.title}</div>
+                <div>{moment(selectedEvent.start).format('ddd, MMM D')} • {moment(selectedEvent.start).format('HH:mm')} - {moment(selectedEvent.end).format('HH:mm')}</div>
+              </div>
+              <div className="space-y-2">
+                <button className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700" onClick={handleStartSelectedSession}>
+                  Start session
+                </button>
+                <button className="w-full px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700" onClick={handleSkipSelectedSession}>
+                  Skip this session for {moment(selectedEvent.start).format('MMM D')}
+                </button>
+                <button className="w-full px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600" onClick={() => setSelectedEvent(null)}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Session Cascade Modal */}
       {pendingSessionCascade && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={() => setPendingSessionCascade(null)}>

--- a/src/components/MobileCalendarView.tsx
+++ b/src/components/MobileCalendarView.tsx
@@ -781,21 +781,54 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
                   </>
                 )}
                 
-                {selectedEvent.resource.type === 'study' && onSelectTask && (
-                  <button
-                    onClick={() => {
-                      onSelectTask(selectedEvent.resource.data.task, {
-                        allocatedHours: selectedEvent.resource.data.session.allocatedHours,
-                        planDate: moment(selectedDate).format('YYYY-MM-DD'),
-                        sessionNumber: selectedEvent.resource.data.session.sessionNumber
-                      });
-                      setSelectedEvent(null);
-                    }}
-                    className="w-full bg-blue-500 text-white py-3 px-4 rounded-lg hover:bg-blue-600 transition-colors flex items-center justify-center space-x-2"
-                  >
-                    <Play size={16} />
-                    <span>Start Study Session</span>
-                  </button>
+                {selectedEvent.resource.type === 'study' && (
+                  <div className="w-full space-y-2">
+                    {onSelectTask && (
+                      <button
+                        onClick={() => {
+                          onSelectTask(selectedEvent.resource.data.task, {
+                            allocatedHours: selectedEvent.resource.data.session.allocatedHours,
+                            planDate: moment(selectedDate).format('YYYY-MM-DD'),
+                            sessionNumber: selectedEvent.resource.data.session.sessionNumber
+                          });
+                          setSelectedEvent(null);
+                        }}
+                        className="w-full bg-blue-500 text-white py-3 px-4 rounded-lg hover:bg-blue-600 transition-colors flex items-center justify-center space-x-2"
+                      >
+                        <Play size={16} />
+                        <span>Start Study Session</span>
+                      </button>
+                    )}
+                    {onUpdateStudyPlans && (
+                      <button
+                        onClick={() => {
+                          const planDate = moment(selectedDate).format('YYYY-MM-DD');
+                          const session = selectedEvent.resource.data.session as StudySession;
+                          const updatedPlans = studyPlans.map(p => {
+                            if (p.date !== planDate) return p;
+                            return {
+                              ...p,
+                              plannedTasks: p.plannedTasks.map(s => {
+                                if (s.taskId === session.taskId && s.sessionNumber === session.sessionNumber) {
+                                  return {
+                                    ...s,
+                                    status: 'skipped' as const,
+                                    skipMetadata: { skippedAt: new Date().toISOString(), reason: 'user_choice' }
+                                  };
+                                }
+                                return s;
+                              })
+                            };
+                          });
+                          onUpdateStudyPlans(updatedPlans);
+                          setSelectedEvent(null);
+                        }}
+                        className="w-full bg-red-500 text-white py-3 px-4 rounded-lg hover:bg-red-600 transition-colors flex items-center justify-center"
+                      >
+                        <span>Skip this session</span>
+                      </button>
+                    )}
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Purpose
The user reported that clicking on calendar blocks (commitments/sessions) was incorrectly redirecting to the timer instead of showing the expected modal dialog. This fix ensures that calendar events display proper modal interfaces for user interaction.

## Code changes
- **CalendarView.tsx**: Replaced direct timer redirection with modal state management for both study sessions and commitments
  - Added `selectedEvent` and `selectedCommitmentEvent` state variables
  - Modified `handleSelectEvent` to set modal state instead of immediate navigation
  - Added new handler functions for starting/skipping sessions and commitments
  - Implemented modal components for study sessions and commitments with start/skip options
  - Fixed date handling in session rescheduling logic

- **MobileCalendarView.tsx**: Enhanced mobile calendar event handling
  - Added skip session functionality alongside existing start session button
  - Improved button layout and user interaction options

- **Service worker**: Updated revision hash for deploymentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f070df200f21427ab9b3afe87b00c020/quantum-field)

👀 [Preview Link](https://f070df200f21427ab9b3afe87b00c020-quantum-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f070df200f21427ab9b3afe87b00c020</projectId>-->
<!--<branchName>quantum-field</branchName>-->